### PR TITLE
Implement storage helpers and add server regression tests

### DIFF
--- a/functions/db.py
+++ b/functions/db.py
@@ -1,52 +1,179 @@
+from __future__ import annotations
+
+import base64
+import math
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
 import firebase_admin
 from firebase_admin import credentials, firestore
-from typing import List, Dict, Any, Optional
 from google.oauth2.credentials import Credentials
 
+
 class FirestoreDB:
-    def __init__(self, service_account_key_path: str):
-        if not firebase_admin._apps:
-            cred = credentials.Certificate(service_account_key_path)
-            firebase_admin.initialize_app(cred)
-        self.db = firestore.client()
+    """Small Firestore wrapper that also supports an in-memory fallback.
 
-    def add_image_data(self, user_id: str, image_data: Dict[str, Any]):
-        # Store image data in a user-specific collection
-        self.db.collection('users').document(user_id).collection('images').add(image_data)
+    The production deployment stores image metadata and embeddings inside
+    Firestore.  For tests (or local development without credentials) we fall
+    back to an in-memory store that mimics the Firestore API used by the
+    server.  Image binaries can be provided either as raw bytes (``image_bytes``
+    / ``thumb_bytes``) or as local file paths.  When only file paths are
+    available the server reads from disk.
+    """
 
-    def search_vectors(self, user_id: str, query_vector: List[float], top_k: int) -> List[Dict[str, Any]]:
-        # This is a simplified search. For production, you'd use a dedicated vector search service
-        # or Firestore's upcoming vector search capabilities.
-        images_ref = self.db.collection('users').document(user_id).collection('images')
-        all_images = images_ref.stream()
+    _IMAGES_COLLECTION = "images"
 
-        # This is a placeholder for actual vector search logic
-        # In a real app, you would not pull all documents and compare locally.
-        results = []
-        for img in all_images:
-            img_dict = img.to_dict()
-            # Faking distance calculation
-            img_dict['distance'] = 0.5 
-            results.append(img_dict)
+    def __init__(self, service_account_key_path: Optional[str]):
+        self._service_account_key_path = service_account_key_path
+        self._local_images: Dict[str, Dict[str, Any]] = {}
+        self._local_users: Dict[str, Dict[str, Any]] = {}
+        self._use_firestore = False
 
-        return sorted(results, key=lambda x: x['distance'])[:top_k]
+        key_path = Path(service_account_key_path) if service_account_key_path else None
+        if key_path and key_path.exists():
+            if not firebase_admin._apps:
+                cred = credentials.Certificate(os.fspath(key_path))
+                firebase_admin.initialize_app(cred)
+            self.db = firestore.client()
+            self._use_firestore = True
+        else:
+            # Fall back to an in-memory store when credentials are missing.
+            self.db = None
 
+    # ------------------------------------------------------------------
+    # Image helpers
+    # ------------------------------------------------------------------
+    def add_image_data(self, image_data: Dict[str, Any], user_id: Optional[str] = None) -> str:
+        """Persist metadata for an image and return its identifier."""
+
+        data = dict(image_data)
+        if user_id:
+            data.setdefault("user_id", user_id)
+
+        embedding = data.get("embedding")
+        if embedding is not None:
+            data["embedding"] = [float(x) for x in embedding]
+
+        image_id = data.pop("image_id", None) or data.get("image_rowid")
+        image_id = str(image_id) if image_id is not None else None
+
+        if self._use_firestore:
+            images_ref = self.db.collection(self._IMAGES_COLLECTION)
+            if image_id:
+                doc_ref = images_ref.document(image_id)
+            else:
+                doc_ref = images_ref.document()
+                image_id = doc_ref.id
+            data.setdefault("image_rowid", image_id)
+            doc_ref.set(data)
+        else:
+            if image_id is None:
+                image_id = str(len(self._local_images) + 1)
+            data.setdefault("image_rowid", image_id)
+            self._local_images[image_id] = data
+
+        return image_id
+
+    def search(self, query_vector: List[float], top_k: int = 20, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Return the ``top_k`` closest matches for ``query_vector``."""
+
+        return self.search_vectors(query_vector=query_vector, top_k=top_k, user_id=user_id)
+
+    def search_vectors(
+        self, query_vector: List[float], top_k: int, user_id: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        results: List[Dict[str, Any]] = []
+
+        for doc_id, data in self._iter_image_documents(user_id=user_id):
+            embedding = data.get("embedding")
+            if not embedding:
+                continue
+            distance = self._cosine_distance(query_vector, embedding)
+            if math.isinf(distance):
+                continue
+            record = {
+                "image_rowid": data.get("image_rowid") or doc_id,
+                "distance": distance,
+                "description": data.get("description"),
+                "album_title": data.get("album_title"),
+                "timestamp": data.get("timestamp"),
+                "thumb_path": data.get("thumb_path"),
+                "thumb_url": data.get("thumb_url"),
+                "file_path": data.get("file_path"),
+                "image_url": data.get("image_url"),
+                "user_id": data.get("user_id"),
+            }
+            results.append(record)
+
+        results.sort(key=lambda item: item["distance"])
+        return results[:top_k]
+
+    def get_image_paths(self, image_id: str | int) -> Tuple[Optional[str], Optional[str]]:
+        """Return file paths for an image and its thumbnail, if present."""
+
+        doc = self._get_image_document(image_id)
+        if not doc:
+            return None, None
+        return doc.get("file_path"), doc.get("thumb_path")
+
+    def get_image_blob(self, image_id: str | int, prefer_thumb: bool = False) -> Tuple[Optional[bytes], Optional[str]]:
+        """Return raw image bytes and mime type for ``image_id``.
+
+        When ``prefer_thumb`` is ``True`` the thumbnail is returned if available.
+        """
+
+        doc = self._get_image_document(image_id)
+        if not doc:
+            return None, None
+
+        mime_type = doc.get("mime_type", "image/jpeg")
+        blob_key = "thumb_bytes" if prefer_thumb else "image_bytes"
+        blob = doc.get(blob_key)
+
+        if isinstance(blob, bytes):
+            return blob, mime_type
+        if isinstance(blob, str):
+            try:
+                return base64.b64decode(blob), mime_type
+            except Exception:
+                return blob.encode("utf-8"), mime_type
+
+        path_key = "thumb_path" if prefer_thumb else "file_path"
+        file_path = doc.get(path_key)
+        if file_path and os.path.exists(file_path):
+            with open(file_path, "rb") as fh:
+                return fh.read(), mime_type
+
+        return None, mime_type
+
+    # ------------------------------------------------------------------
+    # User helpers (settings + credentials)
+    # ------------------------------------------------------------------
     def get_user_settings(self, uid: str) -> dict:
-        """Retrieves a user's settings from Firestore."""
-        doc_ref = self.db.collection("users").document(uid)
-        doc = doc_ref.get()
-        if not doc.exists:
-            return {}
-        return doc.to_dict().get("settings", {})
+        """Retrieves a user's settings."""
+
+        if self._use_firestore:
+            doc_ref = self.db.collection("users").document(uid)
+            doc = doc_ref.get()
+            if not doc.exists:
+                return {}
+            return doc.to_dict().get("settings", {})
+        return self._local_users.get(uid, {}).get("settings", {})
 
     def save_user_settings(self, uid: str, settings: dict):
-        """Saves a user's settings to Firestore."""
-        doc_ref = self.db.collection("users").document(uid)
-        doc_ref.set({"settings": settings}, merge=True)
+        """Saves a user's settings."""
+
+        if self._use_firestore:
+            doc_ref = self.db.collection("users").document(uid)
+            doc_ref.set({"settings": settings}, merge=True)
+        else:
+            user_doc = self._local_users.setdefault(uid, {})
+            user_doc["settings"] = settings
 
     def save_google_photos_credentials(self, uid: str, creds: Credentials):
-        """Saves Google Photos credentials to Firestore for a user."""
-        doc_ref = self.db.collection("users").document(uid)
+        """Saves Google Photos credentials for a user."""
+
         creds_dict = {
             "token": creds.token,
             "refresh_token": creds.refresh_token,
@@ -55,32 +182,90 @@ class FirestoreDB:
             "client_secret": creds.client_secret,
             "scopes": creds.scopes,
         }
-        doc_ref.set({"google_photos_credentials": creds_dict}, merge=True)
+
+        if self._use_firestore:
+            doc_ref = self.db.collection("users").document(uid)
+            doc_ref.set({"google_photos_credentials": creds_dict}, merge=True)
+        else:
+            user_doc = self._local_users.setdefault(uid, {})
+            user_doc["google_photos_credentials"] = creds_dict
 
     def get_google_photos_credentials(self, uid: str) -> Optional[Credentials]:
-        """Retrieves Google Photos credentials from Firestore for a user."""
-        doc_ref = self.db.collection("users").document(uid)
-        doc = doc_ref.get()
-        if not doc.exists:
-            return None
+        """Retrieves Google Photos credentials for a user."""
 
-        creds_dict = doc.to_dict().get("google_photos_credentials")
+        if self._use_firestore:
+            doc_ref = self.db.collection("users").document(uid)
+            doc = doc_ref.get()
+            if not doc.exists:
+                return None
+            creds_dict = doc.to_dict().get("google_photos_credentials")
+        else:
+            creds_dict = self._local_users.get(uid, {}).get("google_photos_credentials")
+
         if not creds_dict:
             return None
-
         return Credentials(**creds_dict)
 
     def save_user_info(self, uid: str, user_info: dict):
-        """Saves user info (like email) to Firestore."""
-        doc_ref = self.db.collection("users").document(uid)
-        doc_ref.set({"user_info": user_info}, merge=True)
+        """Saves user info (like email)."""
+
+        if self._use_firestore:
+            doc_ref = self.db.collection("users").document(uid)
+            doc_ref.set({"user_info": user_info}, merge=True)
+        else:
+            user_doc = self._local_users.setdefault(uid, {})
+            user_doc["user_info"] = user_info
 
     def get_user_info(self, uid: str) -> dict:
-        """Retrieves user info from Firestore."""
-        doc_ref = self.db.collection("users").document(uid)
-        doc = doc_ref.get()
-        if not doc.exists:
-            return {}
-        return doc.to_dict().get("user_info", {})
+        """Retrieves stored user info."""
+
+        if self._use_firestore:
+            doc_ref = self.db.collection("users").document(uid)
+            doc = doc_ref.get()
+            if not doc.exists:
+                return {}
+            return doc.to_dict().get("user_info", {})
+        return self._local_users.get(uid, {}).get("user_info", {})
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _iter_image_documents(self, user_id: Optional[str]) -> Iterable[Tuple[str, Dict[str, Any]]]:
+        if self._use_firestore:
+            collection = self.db.collection(self._IMAGES_COLLECTION)
+            for doc in collection.stream():
+                data = doc.to_dict() or {}
+                if user_id and data.get("user_id") not in (None, user_id):
+                    continue
+                yield doc.id, data
+        else:
+            for image_id, data in self._local_images.items():
+                if user_id and data.get("user_id") not in (None, user_id):
+                    continue
+                yield image_id, data
+
+    def _get_image_document(self, image_id: str | int) -> Optional[Dict[str, Any]]:
+        key = str(image_id)
+        if self._use_firestore:
+            doc = self.db.collection(self._IMAGES_COLLECTION).document(key).get()
+            if not doc.exists:
+                return None
+            data = doc.to_dict() or {}
+            data.setdefault("image_rowid", key)
+            return data
+        return self._local_images.get(key)
+
+    @staticmethod
+    def _cosine_distance(vec1: List[float], vec2: List[float]) -> float:
+        if not vec1 or not vec2:
+            return math.inf
+
+        dot = sum(a * b for a, b in zip(vec1, vec2))
+        norm1 = math.sqrt(sum(a * a for a in vec1))
+        norm2 = math.sqrt(sum(b * b for b in vec2))
+        if norm1 == 0 or norm2 == 0:
+            return math.inf
+        cosine = dot / (norm1 * norm2)
+        return 1 - cosine
 
 

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -1,0 +1,110 @@
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure the functions package is importable when running tests from repo root.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "functions"))
+
+import server  # type: ignore  # noqa: E402
+
+
+@pytest.fixture
+def test_client(monkeypatch, tmp_path):
+    image_bytes = b"fake-image-bytes"
+    thumb_bytes = b"fake-thumb-bytes"
+    image_path = tmp_path / "image.jpg"
+    thumb_path = tmp_path / "thumb.jpg"
+    image_path.write_bytes(image_bytes)
+    thumb_path.write_bytes(thumb_bytes)
+
+    class StubFirestoreDB:
+        def __init__(self, *args, **kwargs):
+            self._image_path = image_path
+            self._thumb_path = thumb_path
+
+        def search(self, query_vector, top_k=20, user_id=None):
+            return [
+                {
+                    "image_rowid": "1",
+                    "distance": 0.125,
+                    "description": "Sample description",
+                    "album_title": "Sample Album",
+                    "timestamp": "2024-01-01T00:00:00Z",
+                    "thumb_path": str(self._thumb_path),
+                    "file_path": str(self._image_path),
+                }
+            ]
+
+        def get_image_blob(self, image_rowid, prefer_thumb=False):
+            if str(image_rowid) != "1":
+                return None, None
+            path = self._thumb_path if prefer_thumb else self._image_path
+            return path.read_bytes(), "image/jpeg"
+
+    class StubGeminiClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def embed_text(self, text):
+            return [0.0, 0.0]
+
+    monkeypatch.setattr(server, "FirestoreDB", StubFirestoreDB)
+    monkeypatch.setattr(server, "GeminiClient", StubGeminiClient)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            f"""
+            db:
+              service_account_key_path: ""
+              dimension: 4
+            llm:
+              oracle_model: "fake"
+              embedding_model: "fake"
+              api_key_env: "FAKE_KEY"
+            google_photos:
+              client_secret_path: ""
+              scopes: []
+              redirect_port: 1008
+              token_store: "{tmp_path / 'token.json'}"
+            storage:
+              images_dir: "{tmp_path / 'images'}"
+              thumbs_dir: "{tmp_path / 'thumbs'}"
+              max_download_size: "w2048-h2048"
+            """
+        ).strip()
+    )
+
+    app = server.create_app(config_path=str(config_path))
+    app.dependency_overrides[server.get_current_user] = lambda: {"uid": "user-123"}
+    client = TestClient(app)
+    return client, image_bytes, thumb_bytes
+
+
+def test_search_route_returns_results(test_client):
+    client, _, _ = test_client
+    response = client.get("/search", params={"q": "diagram"}, headers={"Authorization": "Bearer token"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    item = payload[0]
+    assert item["image_rowid"] == "1"
+    assert item["thumb_url"].endswith("/image/1?thumb=1")
+    assert item["distance"] == pytest.approx(0.125)
+
+
+def test_image_route_returns_binary(test_client):
+    client, image_bytes, thumb_bytes = test_client
+
+    response = client.get("/image/1")
+    assert response.status_code == 200
+    assert response.content == image_bytes
+    assert response.headers["content-type"] == "image/jpeg"
+
+    thumb_response = client.get("/image/1", params={"thumb": 1})
+    assert thumb_response.status_code == 200
+    assert thumb_response.content == thumb_bytes
+    assert thumb_response.headers["content-type"] == "image/jpeg"


### PR DESCRIPTION
## Summary
- extend the Firestore wrapper with an in-memory fallback, vector search helper, and image blob retrieval so metadata and binaries stay consistent
- update the FastAPI server to leverage the new helpers and generate thumbnail URLs that map to stored content
- add regression tests that exercise /search and /image to ensure the routes return valid responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf5cb3b1588325851105544c2eabda