### PR TITLE
Fix popup view state casing

### DIFF
--- a/frontend/src/ExtensionPopup.jsx
+++ b/frontend/src/ExtensionPopup.jsx
@@ -38,12 +38,12 @@ export default function ExtensionPopup() {
     setError("");
     setLoading(true);
     try {
-      setView("Results");
+      setView("query");
       const results = await makeAuthenticatedRequest(`/search?q=${query}`);
       setSearchResults(results);
     } catch (error) {
       setError("Failed to search. Is the local server running?");
-      setView("Query"); // Go back to query view on error
+      setView("query"); // Go back to query view on error
     } finally {
       setLoading(false);
     }
@@ -53,20 +53,20 @@ export default function ExtensionPopup() {
     try {
       // No need to check local storage for token, auth state is the source of truth
       if (!user) {
-        setView("Landing");
+        setView("landing");
         return;
       }
 
       const settings = await makeAuthenticatedRequest("/settings");
 
       if (settings && settings.album_url && settings.gemini_key_set) {
-        setView("Query");
+        setView("query");
       } else {
-        setView("Landing");
+        setView("landing");
       }
     } catch (error) {
       console.error("Failed to check readiness:", error);
-      setView("Landing"); // Fallback to landing on error
+      setView("landing"); // Fallback to landing on error
     }
   };
 


### PR DESCRIPTION
## Summary
- align popup view transitions with lowercase route keys used by the render logic
- keep search and readiness flows on the query/landing views instead of a missing Results state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf5cb026a083259e9a5de7279b40ec