### PR TITLE
Ensure query search button uses the query value

### DIFF
--- a/frontend/src/pages/Query.jsx
+++ b/frontend/src/pages/Query.jsx
@@ -1,6 +1,16 @@
 import { Search } from "lucide-react";
 
 export default function Query({ query, setQuery, onSearch, loading }) {
+  const trimmedQuery = query?.trim() ?? "";
+
+  const handleSearch = () => {
+    if (!trimmedQuery || loading) {
+      return;
+    }
+
+    onSearch(query);
+  };
+
   return (
     <div className="space-y-3">
       <div className="flex space-x-2">
@@ -9,9 +19,19 @@ export default function Query({ query, setQuery, onSearch, loading }) {
           placeholder="Describe the chart, infographic, or topic"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleSearch();
+            }
+          }}
           className="flex-grow p-2 border border-gray-300 rounded-md"
         />
-        <button className="p-2 bg-black text-white rounded-md" onClick={onSearch} disabled={loading}>
+        <button
+          className="p-2 bg-black text-white rounded-md"
+          onClick={handleSearch}
+          disabled={loading || !trimmedQuery}
+        >
           <Search className="h-4 w-4" />
         </button>
       </div>


### PR DESCRIPTION
## Summary
- call the search handler with the current query value instead of the click event
- prevent empty searches by disabling the button when the query is blank and handle pressing Enter in the input

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68cf5cb155f88325ab9a7613d0145b52