### PR TITLE
Enhance ingestion flow and extension context menu

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -7,10 +7,14 @@
     "default_popup": "popup.html",
     "default_icon": "icons/icon.png"
   },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
   "host_permissions": [
     "https://us-central1-source-bruh.cloudfunctions.net/*"
   ],
-  "permissions": ["offscreen"],
+  "permissions": ["offscreen", "contextMenus", "storage", "notifications"],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
   }

--- a/frontend/src/ExtensionPopup.jsx
+++ b/frontend/src/ExtensionPopup.jsx
@@ -19,6 +19,10 @@ export default function ExtensionPopup() {
   const serverBase = extCfg.serverBaseUrl;
 
   useEffect(() => {
+    const hasChrome = typeof chrome !== "undefined" && chrome?.storage?.local;
+    if (hasChrome) {
+      chrome.storage.local.set({ serverBaseUrl: serverBase });
+    }
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
         const token = await user.getIdToken();
@@ -26,8 +30,14 @@ export default function ExtensionPopup() {
         // For example, in a context or a global state management library.
         // For simplicity here, we can store it in localStorage, though this is not the most secure method for extensions.
         localStorage.setItem('firebaseIdToken', token);
+        if (hasChrome) {
+          chrome.storage.local.set({ firebaseIdToken: token });
+        }
       } else {
         localStorage.removeItem('firebaseIdToken');
+        if (hasChrome) {
+          chrome.storage.local.remove('firebaseIdToken');
+        }
       }
       setUser(user);
     });

--- a/frontend/src/background.js
+++ b/frontend/src/background.js
@@ -1,0 +1,84 @@
+import extCfg from "./extension-config.json";
+
+const MENU_ID = "source-bruh-add-image";
+
+const getFromStorage = (keys) =>
+  new Promise((resolve) => {
+    const storage = chrome.storage?.local;
+    if (!storage) {
+      resolve({});
+      return;
+    }
+    storage.get(keys, (result) => resolve(result || {}));
+  });
+
+const setInStorage = (items) =>
+  new Promise((resolve) => {
+    const storage = chrome.storage?.local;
+    if (!storage) {
+      resolve();
+      return;
+    }
+    storage.set(items, () => resolve());
+  });
+
+const showNotification = (message, isError = false) => {
+  if (!chrome.notifications?.create) {
+    const logger = isError ? console.error : console.log;
+    logger(message);
+    return;
+  }
+  chrome.notifications.create({
+    type: "basic",
+    iconUrl: "icons/icon.png",
+    title: "Source Bruh",
+    message,
+  });
+};
+
+chrome.runtime.onInstalled.addListener(async () => {
+  chrome.contextMenus.create({
+    id: MENU_ID,
+    title: "Add image to Source Bruh",
+    contexts: ["image"],
+  });
+  await setInStorage({ serverBaseUrl: extCfg.serverBaseUrl });
+});
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId !== MENU_ID || !info.srcUrl) {
+    return;
+  }
+  const stored = await getFromStorage(["firebaseIdToken", "serverBaseUrl"]);
+  const token = stored.firebaseIdToken;
+  const baseUrl = stored.serverBaseUrl || extCfg.serverBaseUrl;
+
+  if (!token) {
+    showNotification("Sign in through the extension before adding images.", true);
+    return;
+  }
+
+  try {
+    await setInStorage({ serverBaseUrl: baseUrl });
+    const response = await fetch(`${baseUrl}/images/from-url`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        image_url: info.srcUrl,
+        page_url: info.pageUrl || tab?.url || null,
+      }),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(detail || `HTTP ${response.status}`);
+    }
+
+    showNotification("Image added to Source Bruh.");
+  } catch (error) {
+    showNotification(`Failed to add image: ${error.message}`, true);
+  }
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,6 +9,12 @@ export default defineConfig({
       input: {
         popup: new URL('./popup.html', import.meta.url).pathname,
         offscreen: new URL('./offscreen.html', import.meta.url).pathname,
+        background: new URL('./src/background.js', import.meta.url).pathname,
+      },
+      output: {
+        entryFileNames: '[name].js',
+        chunkFileNames: 'chunks/[name].js',
+        assetFileNames: 'assets/[name][extname]',
       },
     },
   },

--- a/functions/photos_client.py
+++ b/functions/photos_client.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 import os
 import requests
 import secrets
@@ -8,19 +8,101 @@ import urllib.parse
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.oauth2.credentials import Credentials
+from google.auth.transport.requests import Request
 import json
-from db import FirestoreDB
-from omegaconf import DictConfig
+try:  # pragma: no cover
+    from .db import FirestoreDB
+except ImportError:  # pragma: no cover
+    from db import FirestoreDB
 
 
 class GooglePhotosClient:
-    def __init__(self, cfg: DictConfig, db: FirestoreDB):
-        self.cfg = cfg
+    def __init__(
+        self,
+        *,
+        client_secret_path: Optional[str],
+        scopes: Iterable[str],
+        redirect_port: int,
+        token_store: Optional[str] = None,
+        oauth_client: Optional[Dict[str, Any]] = None,
+        db: Optional[FirestoreDB] = None,
+        user_id: Optional[str] = None,
+        service: Any = None,
+        credentials: Optional[Credentials] = None,
+    ) -> None:
+        self.client_secret_path = client_secret_path
+        self.scopes = list(scopes or [])
+        if not self.scopes and service is None and credentials is None:
+            raise ValueError("At least one Google Photos scope is required")
+        self.redirect_port = redirect_port
+        self.token_store = token_store
+        self.oauth_client = oauth_client or {}
         self.db = db
-        self.oauth_client = cfg.oauth_client
-        self.redirect_port = cfg.redirect_port
-        self.scopes = list(cfg.scopes)
-        self.token_store = cfg.token_store  # Keep for local dev maybe, but not for cloud
+        self.user_id = user_id
+        self._service = service
+        self._credentials = credentials
+        self.user_email: Optional[str] = None
+        self.code_verifier: Optional[str] = None
+
+    @property
+    def service(self):
+        if self._service is None:
+            self._service = self._build_service()
+        return self._service
+
+    def _load_credentials_from_db(self) -> Optional[Credentials]:
+        if not self.db or not self.user_id:
+            return None
+        try:
+            creds = self.db.get_google_photos_credentials(self.user_id)
+        except Exception:
+            return None
+        return creds
+
+    def _load_credentials_from_token_store(self) -> Optional[Credentials]:
+        if not self.token_store or not os.path.exists(self.token_store):
+            return None
+        try:
+            with open(self.token_store, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            return Credentials.from_authorized_user_info(data, scopes=self.scopes or None)
+        except Exception:
+            return None
+
+    def _persist_credentials(self, creds: Credentials) -> None:
+        if self.token_store:
+            try:
+                with open(self.token_store, "w", encoding="utf-8") as fh:
+                    fh.write(creds.to_json())
+            except Exception:
+                pass
+        if self.db and self.user_id:
+            try:
+                self.db.save_google_photos_credentials(self.user_id, creds)
+            except Exception:
+                pass
+
+    def _build_flow(self) -> InstalledAppFlow:
+        if self.client_secret_path and os.path.exists(self.client_secret_path):
+            return InstalledAppFlow.from_client_secrets_file(self.client_secret_path, self.scopes)
+        if self.oauth_client:
+            redirect_uri = f"http://localhost:{self.redirect_port}/"
+            return InstalledAppFlow.from_client_config(self.oauth_client, self.scopes, redirect_uri=redirect_uri)
+        raise FileNotFoundError(
+            "Missing Google OAuth client credentials; set google_photos.client_secret_path or google_photos.oauth_client in config.yaml",
+        )
+
+    def _ensure_credentials(self, creds: Optional[Credentials]) -> Credentials:
+        if creds and getattr(creds, "expired", False) and getattr(creds, "refresh_token", None):
+            try:
+                creds.refresh(Request())
+            except Exception:
+                creds = None
+        if creds and getattr(creds, "valid", False):
+            return creds
+        flow = self._build_flow()
+        creds = flow.run_local_server(port=self.redirect_port)
+        return creds
 
     def _generate_pkce_pair(self) -> tuple[str, str]:
         """Generate PKCE code verifier and challenge"""
@@ -58,10 +140,14 @@ class GooglePhotosClient:
 
     def get_credentials_from_db(self, uid: str) -> Optional[Credentials]:
         """Gets user's Google Photos API credentials from Firestore."""
+        if not self.db:
+            return None
         return self.db.get_google_photos_credentials(uid)
 
     def get_user_info_from_db(self, uid: str) -> dict:
         """Gets user's info from Firestore."""
+        if not self.db:
+            return {}
         return self.db.get_user_info(uid)
 
     def get_credentials_from_code(self, code: str, uid: str) -> Credentials:
@@ -85,41 +171,26 @@ class GooglePhotosClient:
         flow.fetch_token(code=code, code_verifier=code_verifier)
         creds = flow.credentials
 
-        # Save credentials to Firestore
-        self.db.save_google_photos_credentials(uid, creds)
+        if self.db:
+            # Save credentials to Firestore
+            self.db.save_google_photos_credentials(uid, creds)
 
-        # Get user info and save to Firestore
-        try:
-            oauth2 = build("oauth2", "v2", credentials=creds)
-            info = oauth2.userinfo().get().execute()
-            self.db.save_user_info(uid, info)
-        except Exception as e:
-            # Log this error but don't fail the whole process
-            print(f"Error fetching user info: {e}")
+            # Get user info and save to Firestore
+            try:
+                oauth2 = build("oauth2", "v2", credentials=creds)
+                info = oauth2.userinfo().get().execute()
+                self.db.save_user_info(uid, info)
+            except Exception as e:
+                # Log this error but don't fail the whole process
+                print(f"Error fetching user info: {e}")
 
         return creds
 
     def _build_service(self):
-        creds = None
-        if self.token_store and os.path.exists(self.token_store):
-            try:
-                with open(self.token_store, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                creds = Credentials.from_authorized_user_info(data, scopes=self.scopes)
-            except Exception:
-                creds = None
-        if not creds or not creds.valid:
-            if self.client_secret_path and os.path.exists(self.client_secret_path):
-                flow = InstalledAppFlow.from_client_secrets_file(self.client_secret_path, self.scopes)
-                creds = flow.run_local_server(port=self.redirect_port)
-            else:
-                # Use PKCE flow for public clients (Chrome extensions)
-                if not self.oauth_client or not self.oauth_client.get("web", {}).get("client_id"):
-                    raise FileNotFoundError("Missing Google OAuth client credentials; set google_photos.oauth_client.web.client_id in config.yaml")
-                creds = self._authenticate_with_pkce()
-            if self.token_store:
-                with open(self.token_store, "w", encoding="utf-8") as f:
-                    f.write(creds.to_json())
+        creds = self._credentials or self._load_credentials_from_db() or self._load_credentials_from_token_store()
+        creds = self._ensure_credentials(creds)
+        self._credentials = creds
+        self._persist_credentials(creds)
         svc = build('photoslibrary', 'v1', credentials=creds, static_discovery=False)
         try:
             oauth2 = build('oauth2', 'v2', credentials=creds)
@@ -144,6 +215,26 @@ class GooglePhotosClient:
         for album in self.list_albums():
             if album.get('title', '').lower() == title.lower():
                 return album
+        return None
+
+    def get_album_by_path(self, path: str) -> Optional[Dict]:
+        normalized = (path or "").strip().strip('/')
+        if not normalized:
+            return None
+        for album in self.list_albums():
+            product_url = album.get('productUrl', '')
+            if product_url:
+                parsed = urllib.parse.urlparse(product_url)
+                product_path = parsed.path.strip('/')
+                if product_path and product_path.lower() == normalized.lower():
+                    return album
+            share_info = album.get('shareInfo') or {}
+            share_url = share_info.get('shareableUrl') or ''
+            if share_url:
+                parsed_share = urllib.parse.urlparse(share_url)
+                share_path = parsed_share.path.strip('/')
+                if share_path and share_path.lower() == normalized.lower():
+                    return album
         return None
 
     def iter_media_items_in_album(self, album_id: str, page_size: int = 100):

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -10,3 +10,4 @@ firebase-admin
 python-dotenv
 firebase-functions
 asgiref
+requests

--- a/functions/tests/test_ingest.py
+++ b/functions/tests/test_ingest.py
@@ -1,0 +1,250 @@
+import datetime
+import io
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+from functions.ingest import create_thumbnail, ingest_once
+
+
+class StubFirestoreDB:
+    def __init__(self) -> None:
+        self.saved: dict[str, dict[str, dict]] = {}
+
+    def has_media_item(self, user_id: str, media_id: str) -> bool:
+        return media_id in self.saved.get(user_id, {})
+
+    def upsert_media_item(self, user_id: str, media_id: str, image_data: dict) -> str:
+        self.saved.setdefault(user_id, {})[media_id] = image_data
+        return media_id
+
+    def get_latest_media_timestamp(self, user_id: str, album_title: str | None = None) -> datetime.datetime | None:
+        items = self.saved.get(user_id, {})
+        best: datetime.datetime | None = None
+        for item in items.values():
+            if album_title and item.get("album_title") != album_title:
+                continue
+            ts = item.get("timestamp")
+            if isinstance(ts, datetime.datetime):
+                if best is None or ts > best:
+                    best = ts
+        return best
+
+
+class StubPhotosClient:
+    def __init__(self, image_bytes: bytes, *, album_path: str = "album/album-1", media_items: list[dict] | None = None) -> None:
+        self.image_bytes = image_bytes
+        self.download_calls: list[tuple[str, str]] = []
+        self._album = {"id": "album-1", "title": "Test", "productUrl": "https://photos.google.com/album/album-1"}
+        self._album_path = album_path
+        self._media_items = media_items or [
+            {
+                "id": "media-1",
+                "mimeType": "image/jpeg",
+                "baseUrl": "https://example.com/media-1",
+                "filename": "image.jpg",
+                "mediaMetadata": {
+                    "creationTime": "2024-01-01T00:00:00Z",
+                    "width": "64",
+                    "height": "32",
+                },
+            }
+        ]
+
+    def get_album_by_title(self, title: str):
+        if title == self._album["title"]:
+            return self._album
+        return None
+
+    def get_album_by_path(self, path: str):
+        if path.strip("/") == self._album_path.strip("/"):
+            return self._album
+        return None
+
+    def iter_media_items_in_album(self, album_id: str):
+        if album_id != self._album["id"]:
+            return
+        for item in self._media_items:
+            yield item
+
+    def download_image_bytes(self, base_url: str, max_size: str) -> bytes:
+        self.download_calls.append((base_url, max_size))
+        return self.image_bytes
+
+
+class StubGeminiClient:
+    def describe_image(self, image_bytes: bytes) -> str:
+        return "stub description"
+
+    def embed_text(self, text: str):
+        return [0.1, 0.2, 0.3]
+
+
+def _make_test_image() -> bytes:
+    img = Image.new("RGB", (16, 16), color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+class IngestOnceTest(unittest.TestCase):
+    def test_ingest_single_media_item(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            images_dir = tmp_path / "images"
+            thumbs_dir = tmp_path / "thumbs"
+            config_path = tmp_path / "config.yaml"
+
+            config_text = textwrap.dedent(
+                f"""
+                server:
+                  host: "127.0.0.1"
+                  port: 8080
+
+                google_photos:
+                  client_secret_path: "{tmp_path / 'client_secret.json'}"
+                  scopes:
+                    - "https://www.googleapis.com/auth/photoslibrary.readonly"
+                  redirect_port: 1008
+                  album_paths:
+                    - "album/album-1"
+                  token_store: "{tmp_path / 'token.json'}"
+
+                llm:
+                  oracle_model: "dummy"
+                  embedding_model: "dummy-embed"
+                  api_key_env: "FAKE_KEY"
+
+                db:
+                  service_account_key_path: "{tmp_path / 'service-account.json'}"
+                  user_id: "tester"
+
+                storage:
+                  images_dir: "{images_dir}"
+                  thumbs_dir: "{thumbs_dir}"
+                  max_download_size: "w800-h800"
+                """
+            ).strip()
+            config_path.write_text(config_text, encoding="utf-8")
+
+            image_bytes = _make_test_image()
+
+            stub_db = StubFirestoreDB()
+            photos_client = StubPhotosClient(image_bytes)
+            gemini_client = StubGeminiClient()
+
+            ingest_once(
+                config_path=str(config_path),
+                db=stub_db,
+                photos_client=photos_client,
+                gemini_client=gemini_client,
+            )
+
+            stored = stub_db.saved["tester"]["media-1"]
+            self.assertEqual(stored["album_title"], "Test")
+            self.assertEqual(stored["description"], "stub description")
+            self.assertEqual(stored["embedding"], [0.1, 0.2, 0.3])
+            self.assertEqual(len(stored["sha256"]), 64)
+            self.assertEqual(stored["album_path"], "album/album-1")
+            self.assertEqual(stored["timestamp_iso"], "2024-01-01T00:00:00Z")
+            self.assertIsInstance(stored["timestamp"], datetime.datetime)
+            self.assertEqual(stored["image_bytes"], image_bytes)
+            self.assertEqual(stored["thumbnail_bytes"], create_thumbnail(image_bytes))
+            self.assertTrue((images_dir / "image.jpg").exists())
+            self.assertTrue((thumbs_dir / "image.jpg").exists())
+            self.assertEqual(len(photos_client.download_calls), 1)
+
+            ingest_once(
+                config_path=str(config_path),
+                db=stub_db,
+                photos_client=photos_client,
+                gemini_client=gemini_client,
+            )
+
+            self.assertEqual(len(stub_db.saved["tester"]), 1)
+            self.assertEqual(len(photos_client.download_calls), 1)
+
+    def test_skips_items_before_latest_timestamp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            images_dir = tmp_path / "images"
+            thumbs_dir = tmp_path / "thumbs"
+            config_path = tmp_path / "config.yaml"
+
+            config_text = textwrap.dedent(
+                f"""
+                server:
+                  host: "127.0.0.1"
+                  port: 8080
+
+                google_photos:
+                  client_secret_path: "{tmp_path / 'client_secret.json'}"
+                  scopes:
+                    - "https://www.googleapis.com/auth/photoslibrary.readonly"
+                  redirect_port: 1008
+                  album_paths:
+                    - "album/album-1"
+                  token_store: "{tmp_path / 'token.json'}"
+
+                llm:
+                  oracle_model: "dummy"
+                  embedding_model: "dummy-embed"
+                  api_key_env: "FAKE_KEY"
+
+                db:
+                  service_account_key_path: "{tmp_path / 'service-account.json'}"
+                  user_id: "tester"
+
+                storage:
+                  images_dir: "{images_dir}"
+                  thumbs_dir: "{thumbs_dir}"
+                  max_download_size: "w800-h800"
+                """
+            ).strip()
+            config_path.write_text(config_text, encoding="utf-8")
+
+            image_bytes = _make_test_image()
+
+            stub_db = StubFirestoreDB()
+            existing_ts = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+            stub_db.upsert_media_item(
+                "tester",
+                "existing",
+                {
+                    "album_title": "Test",
+                    "timestamp": existing_ts,
+                },
+            )
+
+            old_item = {
+                "id": "media-older",
+                "mimeType": "image/jpeg",
+                "baseUrl": "https://example.com/media-older",
+                "filename": "older.jpg",
+                "mediaMetadata": {
+                    "creationTime": "2024-01-01T00:00:00Z",
+                    "width": "32",
+                    "height": "32",
+                },
+            }
+            photos_client = StubPhotosClient(image_bytes, media_items=[old_item])
+            gemini_client = StubGeminiClient()
+
+            ingest_once(
+                config_path=str(config_path),
+                db=stub_db,
+                photos_client=photos_client,
+                gemini_client=gemini_client,
+            )
+
+            # No new items should be added
+            self.assertEqual(len(stub_db.saved["tester"]), 1)
+            # Download should never be attempted for the older item
+            self.assertEqual(len(photos_client.download_calls), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend the ingestion pipeline to resolve album paths, skip previously ingested timestamps, and persist downloaded image bytes alongside Gemini outputs in Firestore
- add Firestore timestamp lookups, Google Photos album path resolution, and targeted ingestion tests to prevent regressions
- expose a signed context-menu upload flow by wiring a background service worker, new API endpoint, and settings panel updates that normalize album paths and share tokens with Chrome storage
- configure the extension build and manifest for the new background worker and permissions while adding the requests dependency

## Testing
- python -m unittest functions.tests.test_ingest

------
https://chatgpt.com/codex/tasks/task_e_68cf5cbe97d48325b4b37e3b62a5f20f