### PR TITLE
Fix GooglePhotosClient initialization and add smoke test

### DIFF
--- a/functions/photos_client.py
+++ b/functions/photos_client.py
@@ -1,26 +1,80 @@
-from typing import Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 import os
 import requests
 import secrets
 import hashlib
 import base64
 import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow
+from google_auth_oauthlib.flow import Flow, InstalledAppFlow
 from google.oauth2.credentials import Credentials
 import json
 from db import FirestoreDB
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 
 class GooglePhotosClient:
-    def __init__(self, cfg: DictConfig, db: FirestoreDB):
+    def __init__(
+        self,
+        cfg: Optional[DictConfig] = None,
+        db: Optional[FirestoreDB] = None,
+        *,
+        client_secret_path: Optional[str] = None,
+        scopes: Optional[Iterable[str]] = None,
+        redirect_port: int = 1008,
+        token_store: Optional[str] = None,
+        oauth_client: Optional[Dict[str, Any]] = None,
+    ):
         self.cfg = cfg
         self.db = db
-        self.oauth_client = cfg.oauth_client
-        self.redirect_port = cfg.redirect_port
-        self.scopes = list(cfg.scopes)
-        self.token_store = cfg.token_store  # Keep for local dev maybe, but not for cloud
+
+        self.oauth_client: Optional[Any] = None
+        self.redirect_port = redirect_port
+        resolved_scopes: Iterable[str] | None = scopes
+        resolved_token_store = token_store
+        resolved_client_secret = client_secret_path
+
+        if cfg is not None:
+            self.oauth_client = getattr(cfg, "oauth_client", None)
+            if self.oauth_client is None:
+                self.oauth_client = oauth_client
+            self.redirect_port = int(getattr(cfg, "redirect_port", redirect_port) or redirect_port)
+            cfg_scopes = getattr(cfg, "scopes", None)
+            if cfg_scopes is not None and scopes is None:
+                resolved_scopes = cfg_scopes
+            cfg_token_store = getattr(cfg, "token_store", None)
+            if cfg_token_store is not None and token_store is None:
+                resolved_token_store = cfg_token_store
+            cfg_client_secret = getattr(cfg, "client_secret_path", None)
+            if cfg_client_secret and client_secret_path is None:
+                resolved_client_secret = cfg_client_secret
+        else:
+            self.oauth_client = oauth_client
+
+        self.scopes = list(resolved_scopes or [])
+        self.token_store = os.fspath(resolved_token_store) if resolved_token_store else None
+        self.client_secret_path = os.fspath(resolved_client_secret) if resolved_client_secret else None
+
+        self.service: Optional[Any] = None
+        self.credentials: Optional[Credentials] = None
+        self.user_email: Optional[str] = None
+        self.code_verifier: Optional[str] = None
+
+    def _client_config_dict(self) -> Dict[str, Any]:
+        if not self.oauth_client:
+            raise RuntimeError("OAuth client configuration is required for this operation.")
+        client_config: Any = self.oauth_client
+        if isinstance(client_config, DictConfig):
+            client_config = OmegaConf.to_container(client_config, resolve=True)  # type: ignore[assignment]
+        if not isinstance(client_config, dict):
+            raise RuntimeError("OAuth client configuration must be a mapping type.")
+        return client_config
+
+    def _ensure_service(self):
+        if self.service is None:
+            self.service = self._build_service()
+        return self.service
 
     def _generate_pkce_pair(self) -> tuple[str, str]:
         """Generate PKCE code verifier and challenge"""
@@ -31,9 +85,13 @@ class GooglePhotosClient:
         return code_verifier, code_challenge
 
     def get_auth_url(self) -> str:
-        client_id = self.oauth_client["web"]["client_id"]
+        client_config = self._client_config_dict()
+        client_info = client_config.get("web") or client_config.get("installed")
+        if not client_info:
+            raise RuntimeError("OAuth client configuration must include a 'web' or 'installed' section.")
+        client_id = client_info["client_id"]
         redirect_uri = f"http://localhost:{self.redirect_port}/"
-        
+
         # Generate PKCE pair
         code_verifier, code_challenge = self._generate_pkce_pair()
         self.code_verifier = code_verifier
@@ -58,10 +116,14 @@ class GooglePhotosClient:
 
     def get_credentials_from_db(self, uid: str) -> Optional[Credentials]:
         """Gets user's Google Photos API credentials from Firestore."""
+        if not self.db:
+            raise RuntimeError("Firestore database client is not configured.")
         return self.db.get_google_photos_credentials(uid)
 
     def get_user_info_from_db(self, uid: str) -> dict:
         """Gets user's info from Firestore."""
+        if not self.db:
+            raise RuntimeError("Firestore database client is not configured.")
         return self.db.get_user_info(uid)
 
     def get_credentials_from_code(self, code: str, uid: str) -> Credentials:
@@ -78,7 +140,7 @@ class GooglePhotosClient:
         
         # Use a flow object to complete the auth process
         flow = InstalledAppFlow.from_client_config(
-            self.oauth_client, self.scopes, redirect_uri=redirect_uri
+            self._client_config_dict(), self.scopes, redirect_uri=redirect_uri
         )
 
         # Exchange code for credentials
@@ -110,16 +172,26 @@ class GooglePhotosClient:
                 creds = None
         if not creds or not creds.valid:
             if self.client_secret_path and os.path.exists(self.client_secret_path):
-                flow = InstalledAppFlow.from_client_secrets_file(self.client_secret_path, self.scopes)
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    self.client_secret_path, self.scopes
+                )
                 creds = flow.run_local_server(port=self.redirect_port)
             else:
                 # Use PKCE flow for public clients (Chrome extensions)
-                if not self.oauth_client or not self.oauth_client.get("web", {}).get("client_id"):
-                    raise FileNotFoundError("Missing Google OAuth client credentials; set google_photos.oauth_client.web.client_id in config.yaml")
+                client_config = self._client_config_dict()
+                client_info = client_config.get("web") or client_config.get("installed")
+                if not client_info or not client_info.get("client_id"):
+                    raise FileNotFoundError(
+                        "Missing Google OAuth client credentials; set google_photos.oauth_client.web.client_id in config.yaml"
+                    )
                 creds = self._authenticate_with_pkce()
             if self.token_store:
                 with open(self.token_store, "w", encoding="utf-8") as f:
                     f.write(creds.to_json())
+        if not creds:
+            raise RuntimeError("Failed to obtain Google Photos credentials.")
+
+        self.credentials = creds
         svc = build('photoslibrary', 'v1', credentials=creds, static_discovery=False)
         try:
             oauth2 = build('oauth2', 'v2', credentials=creds)
@@ -127,13 +199,69 @@ class GooglePhotosClient:
             self.user_email = info.get('email')
         except Exception:
             self.user_email = None
+        self.service = svc
         return svc
+
+    def _authenticate_with_pkce(self) -> Credentials:
+        client_config = self._client_config_dict()
+        redirect_uri = f"http://localhost:{self.redirect_port}/"
+        flow = Flow.from_client_config(client_config, scopes=self.scopes, redirect_uri=redirect_uri)
+
+        code_verifier, code_challenge = self._generate_pkce_pair()
+        self.code_verifier = code_verifier
+
+        auth_url, _ = flow.authorization_url(
+            access_type="offline",
+            include_granted_scopes="true",
+            prompt="consent",
+            code_challenge=code_challenge,
+            code_challenge_method="S256",
+        )
+
+        auth_result: Dict[str, Optional[str]] = {"code": None, "error": None}
+
+        class OAuthCallbackHandler(BaseHTTPRequestHandler):
+            def do_GET(self_inner):  # type: ignore[override]
+                parsed = urllib.parse.urlparse(self_inner.path)
+                params = urllib.parse.parse_qs(parsed.query)
+                if "code" in params:
+                    auth_result["code"] = params["code"][0]
+                    message = "Authentication complete. You may close this window."
+                    status = 200
+                else:
+                    auth_result["error"] = params.get("error", ["Unknown error"])[0]
+                    message = "Authentication failed. You may close this window."
+                    status = 400
+                self_inner.send_response(status)
+                self_inner.send_header("Content-Type", "text/html; charset=utf-8")
+                self_inner.end_headers()
+                self_inner.wfile.write(message.encode("utf-8"))
+
+            def log_message(self_inner, format: str, *args: Any) -> None:  # type: ignore[override]
+                return
+
+        server = HTTPServer(("localhost", self.redirect_port), OAuthCallbackHandler)
+        try:
+            print("Please visit this URL to authorize the application:")
+            print(auth_url)
+            print("\nWaiting for authorization code...")
+            server.handle_request()
+        finally:
+            server.server_close()
+
+        if not auth_result["code"]:
+            error = auth_result["error"] or "Authorization code not received."
+            raise RuntimeError(f"Failed to obtain authorization code: {error}")
+
+        flow.fetch_token(code=auth_result["code"], code_verifier=code_verifier)
+        return flow.credentials
 
     def list_albums(self, page_size: int = 50) -> List[Dict]:
         albums: List[Dict] = []
         next_token: Optional[str] = None
+        service = self._ensure_service()
         while True:
-            result = self.service.albums().list(pageSize=page_size, pageToken=next_token).execute()
+            result = service.albums().list(pageSize=page_size, pageToken=next_token).execute()
             albums.extend(result.get('albums', []))
             next_token = result.get('nextPageToken')
             if not next_token:
@@ -148,11 +276,12 @@ class GooglePhotosClient:
 
     def iter_media_items_in_album(self, album_id: str, page_size: int = 100):
         next_page_token: Optional[str] = None
+        service = self._ensure_service()
         while True:
             body = {"albumId": album_id, "pageSize": page_size}
             if next_page_token:
                 body["pageToken"] = next_page_token
-            result = self.service.mediaItems().search(body=body).execute()
+            result = service.mediaItems().search(body=body).execute()
             items = result.get('mediaItems', [])
             for item in items:
                 yield item

--- a/tests/test_photos_client_smoke.py
+++ b/tests/test_photos_client_smoke.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+import sys
+from typing import Any, Dict, Optional
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "functions"))
+
+from functions.photos_client import GooglePhotosClient  # noqa: E402
+
+
+class _DummyRequest:
+    def __init__(self, payload: Dict[str, Any]):
+        self._payload = payload
+
+    def execute(self) -> Dict[str, Any]:
+        return self._payload
+
+
+class _DummyAlbums:
+    def __init__(self, payload: Dict[str, Any]):
+        self._payload = payload
+
+    def list(self, pageSize: int = 50, pageToken: Optional[str] = None) -> _DummyRequest:  # noqa: N802 - API parity
+        return _DummyRequest(self._payload)
+
+
+class _DummyMediaItems:
+    def __init__(self, payload: Dict[str, Any]):
+        self._payload = payload
+
+    def search(self, body: Dict[str, Any]) -> _DummyRequest:  # noqa: ARG002 - parity with google API
+        return _DummyRequest(self._payload)
+
+
+class _DummyService:
+    def __init__(self, albums_payload: Dict[str, Any], media_payload: Dict[str, Any]):
+        self._albums_payload = albums_payload
+        self._media_payload = media_payload
+
+    def albums(self) -> _DummyAlbums:
+        return _DummyAlbums(self._albums_payload)
+
+    def mediaItems(self) -> _DummyMediaItems:  # noqa: N802 - API parity
+        return _DummyMediaItems(self._media_payload)
+
+
+@pytest.fixture()
+def dummy_service_payloads() -> Dict[str, Dict[str, Any]]:
+    return {
+        "albums": {"albums": [{"title": "Sample"}]},
+        "media": {"mediaItems": [{"id": "1"}]},
+    }
+
+
+def test_list_albums_smoke(monkeypatch: pytest.MonkeyPatch, dummy_service_payloads: Dict[str, Dict[str, Any]]):
+    service = _DummyService(dummy_service_payloads["albums"], dummy_service_payloads["media"])
+    build_calls = {"count": 0}
+
+    def _fake_build(self: GooglePhotosClient):
+        build_calls["count"] += 1
+        self.service = service
+        return service
+
+    monkeypatch.setattr(GooglePhotosClient, "_build_service", _fake_build)
+
+    client = GooglePhotosClient(
+        client_secret_path=None,
+        scopes=["https://www.googleapis.com/auth/photoslibrary.readonly"],
+        redirect_port=1234,
+        token_store=None,
+        oauth_client={
+            "web": {
+                "client_id": "fake-client",
+                "auth_uri": "https://example.com/auth",
+                "token_uri": "https://example.com/token",
+                "redirect_uris": ["http://localhost:1234/"],
+            }
+        },
+    )
+
+    albums = client.list_albums()
+    assert albums == dummy_service_payloads["albums"]["albums"]
+    assert client.service is service
+
+    # Verify the cached service avoids repeated builds.
+    more_albums = client.list_albums()
+    assert more_albums == albums
+    assert build_calls["count"] == 1


### PR DESCRIPTION
## Summary
- normalize GooglePhotosClient configuration handling, including client secret path support and lazy service construction
- implement the PKCE authentication helper and ensure `_build_service` caches credentials and service metadata
- add a pytest smoke test that verifies `list_albums()` works against a mocked service

## Testing
- pytest tests/test_photos_client_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68cf5cb4c0fc83259acddcb7478e32fc