### PR TITLE
Fix popup navigation and auth CSP allowances

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -16,8 +16,19 @@
   ],
   "permissions": ["offscreen", "contextMenus", "storage", "notifications"],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' https://apis.google.com 'wasm-unsafe-eval'; object-src 'self'"
-  }
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval' https://apis.google.com https://www.gstatic.com; object-src 'self'"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "offscreen.html",
+        "offscreen.js",
+        "chunks/*.js",
+        "assets/*"
+      ],
+      "matches": ["<all_urls>"]
+    }
+  ]
 }
 
 

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -48,7 +48,7 @@ async function createOffscreenDocument() {
  * Settings page displayed within the popup. It handles user authentication,
  * Google Photos source configuration and Gemini API key management.
  */
-function Settings() {
+function Settings({ onBackToHome = null }) {
   const [user, setUser] = useState(null);
   const [albumUrl, setAlbumUrl] = useState("");
   const [albumUrlDraft, setAlbumUrlDraft] = useState("");
@@ -109,6 +109,9 @@ function Settings() {
       if (message.type === 'firebase-login-success') {
         setStatusMessage('Signed in successfully.');
         setErrorMessage("");
+        if (onBackToHome) {
+          onBackToHome();
+        }
       } else if (message.type === 'firebase-login-failure') {
         setErrorMessage(`Login failed: ${message.payload}`);
       }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    headers: {
+      "Content-Security-Policy": "script-src 'self' 'wasm-unsafe-eval' 'inline-speculation-rules' http://localhost:* http://127.0.0.1:* https://apis.google.com https://www.gstatic.com; object-src 'self'",
+    },
+  },
   build: {
     outDir: 'dist',
     rollupOptions: {


### PR DESCRIPTION
## Summary
- allow Firebase auth to load its required Google scripts by expanding the CSP and exposing the offscreen bundle
- make the background worker recreate the Source-Me-Bruh context menu whenever it spins up so the ingestion entry is always available
- swap the popup navigation to a stack-based flow and close settings after sign-in so the back button reliably returns to the previous view
- align the Vite dev server headers with the production CSP to avoid auth discrepancies while developing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7812174e0832583823be3438846ea