### PR TITLE
Use Chrome identity flow for Firebase sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ source-bruh/
 2. In Chrome, open `chrome://extensions`, enable **Developer mode**, click **Load unpacked** and select `frontend/dist`.
 3. Click the extension icon to open the popup.
 
+### Configure Google OAuth for Chrome Identity
+
+The extension now relies on `chrome.identity.launchWebAuthFlow` to complete
+Google sign-in without relaxing the manifest Content Security Policy. Before
+attempting to log in:
+
+1. Create (or reuse) an OAuth 2.0 client ID for a Chrome app in the Google Cloud
+   console. The client must list the extension ID’s redirect URL in the form
+   `https://<extension-id>.chromiumapp.org/`.
+2. Add the client ID to Firebase Authentication under **Sign-in method → Google →
+   Web SDK configuration** so Firebase accepts the resulting ID tokens.
+3. Update `frontend/src/extension-config.json` with the client ID and any
+   additional scopes you require. The defaults request basic profile and email
+   access.
+4. Reload the extension so the new configuration is bundled into the offscreen
+   document.
+
 ## Using the Settings page
 
 1. Open the popup and click the gear icon to reach **Settings**.

--- a/frontend/offscreen.html
+++ b/frontend/offscreen.html
@@ -3,14 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <!--
-      This meta tag sets a specific Content Security Policy for this document,
-      allowing it to load the necessary scripts from Google's APIs for Firebase Auth.
-      This is the recommended approach for Manifest V3 extensions.
+      The offscreen document runs the Chrome Identity based OAuth handshake
+      entirely within extension code, so no additional CSP allowances are
+      required beyond the defaults inherited from the manifest.
     -->
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="script-src 'self' https://apis.google.com;"
-    />
   </head>
   <body>
     <!-- This script will handle the Firebase auth flow -->

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -14,9 +14,10 @@
   "host_permissions": [
     "https://us-central1-source-bruh.cloudfunctions.net/*"
   ],
-  "permissions": ["offscreen", "contextMenus", "storage", "notifications"],
+  "permissions": ["offscreen", "contextMenus", "storage", "notifications", "identity"],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval' https://apis.google.com https://www.gstatic.com; object-src 'self'"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",
+    "offscreen": "script-src 'self'; object-src 'self'"
   },
   "web_accessible_resources": [
     {

--- a/frontend/src/extension-config.json
+++ b/frontend/src/extension-config.json
@@ -1,4 +1,10 @@
 {
-  "serverBaseUrl": "https://us-central1-source-bruh.cloudfunctions.net/api"
+  "serverBaseUrl": "https://us-central1-source-bruh.cloudfunctions.net/api",
+  "googleOAuthClientId": null,
+  "googleOAuthScopes": [
+    "openid",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile"
+  ]
 }
 

--- a/frontend/src/firebase.js
+++ b/frontend/src/firebase.js
@@ -1,6 +1,6 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
-import { getAuth, GoogleAuthProvider } from "firebase/auth";
+import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
 // Your web app's Firebase configuration
@@ -18,4 +18,3 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
-export const googleProvider = new GoogleAuthProvider();

--- a/frontend/src/offscreen.js
+++ b/frontend/src/offscreen.js
@@ -1,17 +1,114 @@
-import { auth, googleProvider } from "./firebase";
-import { signInWithPopup } from "firebase/auth";
+import { GoogleAuthProvider, signInWithCredential } from "firebase/auth";
+import { auth } from "./firebase";
+import extensionConfig from "./extension-config.json";
+
+function getConfiguredScopes() {
+  const scopes = extensionConfig.googleOAuthScopes;
+  if (Array.isArray(scopes) && scopes.length > 0) {
+    return scopes;
+  }
+  return ["openid", "https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile"];
+}
+
+function randomString() {
+  const array = new Uint8Array(16);
+  crypto.getRandomValues(array);
+  return Array.from(array, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function buildGoogleOAuthUrl({ clientId, redirectUri, scopes, state, nonce }) {
+  const url = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("response_type", "token id_token");
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("scope", scopes.join(" "));
+  url.searchParams.set("state", state);
+  url.searchParams.set("nonce", nonce);
+  url.searchParams.set("prompt", "select_account");
+  url.searchParams.set("include_granted_scopes", "true");
+  return url.toString();
+}
+
+function launchWebAuthFlow(details) {
+  return new Promise((resolve, reject) => {
+    try {
+      chrome.identity.launchWebAuthFlow(details, (redirectUrl) => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message));
+          return;
+        }
+        resolve(redirectUrl);
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function parseOAuthResponse(url, expectedState) {
+  if (!url) {
+    throw new Error("Google sign-in was cancelled.");
+  }
+
+  const fragmentIndex = url.indexOf("#");
+  const queryIndex = url.indexOf("?");
+  let paramsString = "";
+
+  if (fragmentIndex !== -1) {
+    paramsString = url.substring(fragmentIndex + 1);
+  } else if (queryIndex !== -1) {
+    paramsString = url.substring(queryIndex + 1);
+  }
+
+  const params = new URLSearchParams(paramsString);
+  const returnedState = params.get("state");
+
+  if (expectedState && returnedState && expectedState !== returnedState) {
+    throw new Error("OAuth state mismatch. Please try again.");
+  }
+
+  const idToken = params.get("id_token");
+  if (!idToken) {
+    const errorDescription = params.get("error_description") || params.get("error") || "Missing ID token from Google.";
+    throw new Error(errorDescription);
+  }
+
+  const accessToken = params.get("access_token") || undefined;
+  return { idToken, accessToken };
+}
+
+async function signInWithGoogleViaIdentity() {
+  if (typeof chrome === "undefined" || !chrome.identity?.launchWebAuthFlow) {
+    throw new Error("Chrome identity API is unavailable.");
+  }
+
+  const rawClientId = extensionConfig.googleOAuthClientId;
+  const clientId = typeof rawClientId === "string" ? rawClientId.trim() : "";
+  if (!clientId) {
+    throw new Error("Google OAuth client ID is not configured.");
+  }
+
+  const redirectUri = chrome.identity.getRedirectURL("oauth2");
+  const state = randomString();
+  const nonce = randomString();
+  const scopes = getConfiguredScopes();
+
+  const authUrl = buildGoogleOAuthUrl({ clientId, redirectUri, scopes, state, nonce });
+  const redirectUrl = await launchWebAuthFlow({ url: authUrl, interactive: true });
+  const { idToken, accessToken } = parseOAuthResponse(redirectUrl, state);
+  const credential = GoogleAuthProvider.credential(idToken, accessToken);
+  return signInWithCredential(auth, credential);
+}
 
 // Listen for messages from the extension popup
 chrome.runtime.onMessage.addListener(async (message) => {
-  if (message.type === 'firebase-login') {
+  if (message.type === "firebase-login") {
     try {
-      const result = await signInWithPopup(auth, googleProvider);
-      // Send success message back to the popup
-      chrome.runtime.sendMessage({ type: 'firebase-login-success', payload: result.user });
+      const result = await signInWithGoogleViaIdentity();
+      chrome.runtime.sendMessage({ type: "firebase-login-success", payload: result.user });
     } catch (error) {
-      // Send error message back to the popup
-      chrome.runtime.sendMessage({ type: 'firebase-login-failure', payload: error.message });
+      chrome.runtime.sendMessage({ type: "firebase-login-failure", payload: error.message });
     }
   }
-  return true; // Indicates an async response
+  return true;
 });


### PR DESCRIPTION
## Summary
- replace the offscreen Google popup with a chrome.identity.launchWebAuthFlow based sign-in that no longer tries to load remote scripts
- add the identity permission, tighten the offscreen CSP, and document the OAuth client configuration required for the new flow
- extend the extension config with OAuth client metadata so the auth flow can be customised without touching code

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d97240928c8325bfea1c89e34613e4